### PR TITLE
Hermes/berserk fix (due to Cassidy/Wylem)

### DIFF
--- a/FreeEnt/generator.py
+++ b/FreeEnt/generator.py
@@ -185,6 +185,7 @@ F4C_FILES = '''
     scripts/blank_textbox_fix.f4c
     scripts/cycle_party_leader.f4c
     scripts/item_delivery_quantity.f4c
+    scripts/fix_hermes_berserk.f4c
 '''
 
 BINARY_PATCHES = {

--- a/FreeEnt/scripts/fix_hermes_berserk.f4c
+++ b/FreeEnt/scripts/fix_hermes_berserk.f4c
@@ -1,0 +1,20 @@
+msfpatch {
+    .addr $03ae81
+        jsr $_FixTargetAllHermes
+    
+    .addr $03fee7
+    FixTargetAllHermes:
+        lda #$04          // Berserked status bit
+        ldx #$03
+    %StatusLoop:
+        cmp $2683,x       // Actor status effects
+        beq $+NoAllTarget
+        dex
+        bpl $-StatusLoop
+        lda $1802         // Current battle background
+        bit #$10          // Zeromus battle background, handles Black Hole with berserk queued.
+        bne $+NoAllTarget
+        lda $26d2         // Current actor subcommand. What we wrote over.
+    %NoAllTarget:
+        rts
+}

--- a/FreeEnt/scripts/fix_hermes_berserk.f4c
+++ b/FreeEnt/scripts/fix_hermes_berserk.f4c
@@ -1,20 +1,15 @@
 msfpatch {
     .addr $03ae81
-        jsr $_FixTargetAllHermes
+        jsr $_FixTargetSwoonedHermes
     
     .addr $03fee7
-    FixTargetAllHermes:
-        lda #$04          // Berserked status bit
-        ldx #$03
-    %StatusLoop:
-        cmp $2683,x       // Actor status effects
-        beq $+NoAllTarget
-        dex
-        bpl $-StatusLoop
-        lda $1802         // Current battle background
-        bit #$10          // Zeromus battle background, handles Black Hole with berserk queued.
-        bne $+NoAllTarget
-        lda $26d2         // Current actor subcommand. What we wrote over.
-    %NoAllTarget:
+    FixTargetSwoonedHermes:
+        lda $26d1
+        cmp #$c2
+        bne $+NotLifeAll
+        lda $26d2
+        rts
+    %NotLifeAll:
+        tya
         rts
 }


### PR DESCRIPTION
Cassidy and Wylem wrote a bugfix for the vanilla "Hermes sets a flag to hit swooned/hidden targets" bug; the implementation uses some of the extra end-of-`bank03` space to make an extra check for the "monster white magic" command before letting the game check for the Life-All spell (used only in the vanilla Zeromus cutscene), and otherwise bypasses the possibility of setting the hits-swooned/hidden-targets flag.