### PR TITLE
spells:anti sets Meteo to 56.

### DIFF
--- a/FreeEnt/update_spells.py
+++ b/FreeEnt/update_spells.py
@@ -245,7 +245,8 @@ def spellset_data(env):
             '#Quake' : 38,
             '#Fatal' : 42,
             '#Weak'  : 46,
-            '#Nuke'  : 54
+            '#Nuke'  : 54,
+            '#Meteo' : 56
         })
         spellsets['TellahBlack'].update({
             '#Weak' : 33


### PR DESCRIPTION
This doesn't change the bug where Rydia's baseline level for learning Meteo is set at 56. That is address directly in the main DoorsRando branch with this pr https://github.com/galeswift/FreeEnterpriseGaleswift/pull/29/changes/ad477edeb875544b4540f70d25ffa6bff3ed4a5d and is deliberately left off this PR to not create any conflicts when eventually merging your branch to that.